### PR TITLE
Specify version of uuid.js

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -13,7 +13,7 @@
         <script src="https://code.jquery.com/jquery-2.2.3.min.js"></script>
         <script src="https://cdn.rawgit.com/olton/Metro-UI-CSS/master/build/js/metro.min.js"></script>
         <script src="https://cdn.rawgit.com/jhuckaby/webcamjs/master/webcam.min.js"></script>
-        <script src="https://cdn.rawgit.com/broofa/node-uuid/master/uuid.js"></script>
+        <script src="https://cdn.rawgit.com/kelektiv/node-uuid/v1.4.7/uuid.js"></script>
 
         <title>tPresent</title>
     </head>


### PR DESCRIPTION
An error occurred in the newest version of uuid.js.
"uuid.js:4 Uncaught ReferenceError: require is not defined(…)"